### PR TITLE
build: use vcpkg as a submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2
@@ -36,8 +38,8 @@ jobs:
     - name: Restore NuGet packages
       run: msbuild -t:restore -p:RestorePackagesConfig=true
 
-    - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v11
+    - name: Bootstrap vcpkg
+      run: ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.bat -disableMetrics
 
     - name: Install vcpkg MSBuild integration
       run: ${{ github.workspace }}/vcpkg/vcpkg.exe integrate install
@@ -48,6 +50,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
+        if-no-files-found: error
         name: WinUHid-${{ matrix.configuration }}-${{ matrix.platform }}
         path: |
           build/${{ matrix.configuration }}/${{ matrix.platform }}/WinUHid.*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/microsoft/vcpkg.git
+	branch = master


### PR DESCRIPTION
## Description

Adds vcpkg as a submodule instead of using a GitHub action to set it up. The version of vcpkg is the latest release. If you add dependabot, they will now only update to tagged versions, if the existing version is also a tagged version.

I also made the upload step fail if no artifacts are found.

## Motivation

I've been looking into how to integrate this into Sunshine, and currently it's not the easiest to integrate into Sunshine's build process. Using vcpkg as a submodule would make it a little easier... I think.

I'm not completely sure what all is required/remaining before this can be integrated into Sunshine. If code signing is a limitation, I do have a code signing account now through Azure (though it does not support ARM64 yet).

## Note

Some of the builds are failing, but that is not due to the changes in this PR as I get the same errors when running the workflow for the main branch: https://github.com/ReenigneArcher/WinUHid/actions/runs/23274527994