### PR TITLE
feat(ps5): firmware passthrough, mic LED callback, and feature report stubs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,13 @@ jobs:
       with:
         msbuild-architecture: x64
 
+    - name: Install Windows Driver Kit
+      run: |
+        $wdkUrl = "https://download.microsoft.com/download/41fb59c2-1723-45f9-a270-96b73ad58233/KIT_BUNDLE_WDK_MEDIACREATION/wdksetup.exe"
+        Invoke-WebRequest -Uri $wdkUrl -OutFile "$env:TEMP\wdksetup.exe"
+        Start-Process -FilePath "$env:TEMP\wdksetup.exe" -ArgumentList "/quiet", "/norestart", "/ceip off" -Wait
+      shell: pwsh
+
     - name: Restore NuGet packages
       run: msbuild -t:restore -p:RestorePackagesConfig=true
 
@@ -50,5 +57,5 @@ jobs:
       with:
         name: WinUHid-${{ matrix.configuration }}-${{ matrix.platform }}
         path: |
-          build/${{ matrix.configuration }}/${{ matrix.platform }}/WinUHid.*
+          build/${{ matrix.configuration }}/${{ matrix.platform }}/
           WinUHid/WinUHid.h

--- a/WinUHidDevs/WinUHidPS5.cpp
+++ b/WinUHidDevs/WinUHidPS5.cpp
@@ -224,6 +224,8 @@ typedef struct _WINUHID_PS5_GAMEPAD {
 	WINUHID_PS5_TRIGGER_EFFECT LastRightTriggerEffect, LastLeftTriggerEffect;
 	PWINUHID_PS5_PLAYER_LED_CB PlayerLedCallback;
 	UCHAR LastPlayerLedState;
+	PWINUHID_PS5_MIC_LED_CB MicLedCallback;
+	UCHAR LastMicLedState;
 	PVOID CallbackContext;
 
 	LARGE_INTEGER QpcFrequency;
@@ -233,11 +235,24 @@ typedef struct _WINUHID_PS5_GAMEPAD {
 	UCHAR SequenceNumber;
 
 	UCHAR MacAddress[6];
+	UCHAR FirmwareInfoReport[64];
 } WINUHID_PS5_GAMEPAD, *PWINUHID_PS5_GAMEPAD;
 
 #define PS5_FEATURE_REPORT_CALIBRATION		0x05
 #define PS5_FEATURE_REPORT_PAIRING_INFO		0x09
 #define PS5_FEATURE_REPORT_FIRMWARE_INFO	0x20
+
+static const UCHAR k_DefaultFirmwareInfo[] =
+{
+	0x20, 0x4d, 0x61, 0x72, 0x20, 0x31, 0x35, 0x20,
+	0x32, 0x30, 0x32, 0x35, 0x31, 0x30, 0x3a, 0x30,
+	0x30, 0x3a, 0x30, 0x30, 0x04, 0x00, 0x14, 0x00,
+	0x2c, 0x04, 0x00, 0x00, 0x0a, 0x00, 0x0c, 0x01,
+	0x51, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x58, 0x04, 0x00, 0x00,
+	0x2a, 0x00, 0x01, 0x00, 0x09, 0x00, 0x02, 0x00,
+	0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
 
 #define PS5_OUTPUT_REPORT_EFFECTS           0x02
 
@@ -303,23 +318,8 @@ VOID WinUHidPS5Callback(PVOID CallbackContext, PWINUHID_DEVICE Device, PCWINUHID
 
 		case PS5_FEATURE_REPORT_FIRMWARE_INFO:
 		{
-			//
-			// This is dumped from a PS5 controller running a recent firmware
-			// which supports the newer better rumble support
-			//
-			static const UCHAR data[] =
-			{
-				0x20, 0x4a, 0x61, 0x6e, 0x20, 0x32, 0x39, 0x20,
-				0x32, 0x30, 0x32, 0x34, 0x30, 0x39, 0x3a, 0x31,
-				0x33, 0x3a, 0x35, 0x39, 0x02, 0x00, 0x04, 0x00,
-				0x14, 0x04, 0x00, 0x00, 0x0a, 0x00, 0x0c, 0x01,
-				0x51, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00, 0x58, 0x04, 0x00, 0x00,
-				0x2a, 0x00, 0x01, 0x00, 0x09, 0x00, 0x02, 0x00,
-				0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			};
-
-			WinUHidCompleteReadEvent(Device, Event, data, sizeof(data));
+			WinUHidCompleteReadEvent(Device, Event,
+				gamepad->FirmwareInfoReport, sizeof(gamepad->FirmwareInfoReport));
 			break;
 		}
 
@@ -342,11 +342,18 @@ VOID WinUHidPS5Callback(PVOID CallbackContext, PWINUHID_DEVICE Device, PCWINUHID
 		}
 
 		default:
+		{
 			//
-			// Fail other feature reads that we don't implement
+			// Return zero-filled data for unimplemented feature reports.
+			// Returning NULL causes WebHID clients (Chrome) to timeout/retry
+			// on each unimplemented report during enumeration, leading to
+			// multi-second freezes.
 			//
-			WinUHidCompleteReadEvent(Device, Event, NULL, 0);
+			UCHAR zeroData[64] = {};
+			zeroData[0] = Event->ReportId;
+			WinUHidCompleteReadEvent(Device, Event, zeroData, sizeof(zeroData));
 			break;
+		}
 		}
 	}
 	else if (Event->Type == WINUHID_EVENT_SET_FEATURE) {
@@ -410,6 +417,11 @@ VOID WinUHidPS5Callback(PVOID CallbackContext, PWINUHID_DEVICE Device, PCWINUHID
 			}
 		}
 
+		if (gamepad->MicLedCallback && outputReport->MicMuteLedValid && outputReport->MuteButtonLed != gamepad->LastMicLedState) {
+			gamepad->MicLedCallback(gamepad->CallbackContext, outputReport->MuteButtonLed);
+			gamepad->LastMicLedState = outputReport->MuteButtonLed;
+		}
+
 		WinUHidCompleteWriteEvent(Device, Event, TRUE);
 	}
 }
@@ -417,7 +429,7 @@ VOID WinUHidPS5Callback(PVOID CallbackContext, PWINUHID_DEVICE Device, PCWINUHID
 WINUHID_API PWINUHID_PS5_GAMEPAD WinUHidPS5Create(PCWINUHID_PS5_GAMEPAD_INFO Info,
 	PWINUHID_PS5_RUMBLE_CB RumbleCallback, PWINUHID_PS5_LIGHTBAR_LED_CB LightBarLedCallback,
 	PWINUHID_PS5_PLAYER_LED_CB PlayerLedCallback, PWINUHID_PS5_TRIGGER_EFFECT_CB TriggerEffectCallback,
-	PVOID CallbackContext)
+	PWINUHID_PS5_MIC_LED_CB MicLedCallback, PVOID CallbackContext)
 {
 	WINUHID_DEVICE_CONFIG config = k_PS5Config;
 	PopulateDeviceInfo(&config, Info ? Info->BasicInfo : NULL);
@@ -441,10 +453,19 @@ WINUHID_API PWINUHID_PS5_GAMEPAD WinUHidPS5Create(PCWINUHID_PS5_GAMEPAD_INFO Inf
 	gamepad->LightBarCallback = LightBarLedCallback;
 	gamepad->PlayerLedCallback = PlayerLedCallback;
 	gamepad->TriggerEffectCallback = TriggerEffectCallback;
+	gamepad->MicLedCallback = MicLedCallback;
 	gamepad->CallbackContext = CallbackContext;
 
 	if (Info) {
 		RtlCopyMemory(&gamepad->MacAddress[0], &Info->MacAddress[0], sizeof(gamepad->MacAddress));
+
+		if (Info->FirmwareInfo && Info->FirmwareInfoLength == sizeof(gamepad->FirmwareInfoReport)) {
+			RtlCopyMemory(gamepad->FirmwareInfoReport, Info->FirmwareInfo, sizeof(gamepad->FirmwareInfoReport));
+		} else {
+			RtlCopyMemory(gamepad->FirmwareInfoReport, k_DefaultFirmwareInfo, sizeof(k_DefaultFirmwareInfo));
+		}
+	} else {
+		RtlCopyMemory(gamepad->FirmwareInfoReport, k_DefaultFirmwareInfo, sizeof(k_DefaultFirmwareInfo));
 	}
 
 	WinUHidPS5InitializeInputReport(&gamepad->LastInputReport);

--- a/WinUHidDevs/WinUHidPS5.h
+++ b/WinUHidDevs/WinUHidPS5.h
@@ -136,6 +136,14 @@ typedef WINUHID_PS5_LIGHTBAR_LED_CB* PWINUHID_PS5_LIGHTBAR_LED_CB;
 typedef VOID WINUHID_PS5_PLAYER_LED_CB(PVOID CallbackContext, UCHAR LedValue);
 typedef WINUHID_PS5_PLAYER_LED_CB* PWINUHID_PS5_PLAYER_LED_CB;
 
+//
+// Optional callback to be invoked when mic mute LED state changes
+//
+// Values: 0 = off, 1 = on (solid), 2 = pulse (blink)
+//
+typedef VOID WINUHID_PS5_MIC_LED_CB(PVOID CallbackContext, UCHAR LedState);
+typedef WINUHID_PS5_MIC_LED_CB* PWINUHID_PS5_MIC_LED_CB;
+
 typedef struct _WINUHID_PS5_GAMEPAD_INFO {
 	//
 	// Basic HID and PnP device information (optional)
@@ -146,6 +154,15 @@ typedef struct _WINUHID_PS5_GAMEPAD_INFO {
 	// Unique identifier for this PS5 gamepad
 	//
 	UCHAR MacAddress[6];
+
+	//
+	// Optional raw firmware info report (feature report 0x20).
+	// If non-NULL, this 64-byte blob is served verbatim for
+	// GET_FEATURE 0x20 requests. First byte must be the report
+	// ID (0x20). If NULL, a built-in default is used.
+	//
+	CONST UCHAR *FirmwareInfo;
+	UCHAR FirmwareInfoLength;
 } WINUHID_PS5_GAMEPAD_INFO, * PWINUHID_PS5_GAMEPAD_INFO;
 typedef CONST WINUHID_PS5_GAMEPAD_INFO* PCWINUHID_PS5_GAMEPAD_INFO;
 
@@ -163,7 +180,7 @@ typedef CONST WINUHID_PS5_GAMEPAD_INFO* PCWINUHID_PS5_GAMEPAD_INFO;
 WINUHID_API PWINUHID_PS5_GAMEPAD WinUHidPS5Create(PCWINUHID_PS5_GAMEPAD_INFO Info,
 	PWINUHID_PS5_RUMBLE_CB RumbleCallback, PWINUHID_PS5_LIGHTBAR_LED_CB LightBarLedCallback,
 	PWINUHID_PS5_PLAYER_LED_CB PlayerLedCallback, PWINUHID_PS5_TRIGGER_EFFECT_CB TriggerEffectCallback,
-	PVOID CallbackContext);
+	PWINUHID_PS5_MIC_LED_CB MicLedCallback, PVOID CallbackContext);
 
 //
 // Initializes the input report with neutral data.


### PR DESCRIPTION
## Summary
- Accept optional `FirmwareInfo` blob in `WINUHID_PS5_GAMEPAD_INFO`. When provided, serve it verbatim for `GET_FEATURE 0x20` instead of the built-in default. Enables hosts to pass through the real controller's firmware version from the client.
- Add `PWINUHID_PS5_MIC_LED_CB` callback, invoked when the host sets `MicMuteLedValid` in the output report (values: 0=off, 1=on, 2=pulse).
- Return zero-filled data for unimplemented feature reports instead of NULL, preventing WebHID clients (Chrome) from freezing for 7+ seconds during device enumeration.
- Update default firmware info to a modern version to prevent spurious firmware update prompts when no passthrough data is available.

Also fixes the CI workflow to install WDK on `windows-latest` (no longer pre-installed) and uploads full build output including driver files.

## Test plan
- [x] Virtual DualSense loads instantly on ds.daidr.me (no Chrome freeze)
- [x] No firmware update prompt when connecting via Moonlight
- [x] Firmware passthrough verified end-to-end (physical controller's `Jul 4 2025` firmware appears on virtual device)
- [x] Mic LED callback fires when games set mic mute state
- [x] Existing functionality (rumble, lightbar, adaptive triggers, player LED) unaffected
- [x] Callers that zero-initialize `WINUHID_PS5_GAMEPAD_INFO` get default behavior (backwards compatible)